### PR TITLE
Allow usage of newer versions of Flipper than 0.15

### DIFF
--- a/flipper-echo.gemspec
+++ b/flipper-echo.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_dependency 'flipper', '0.15'
+  spec.add_dependency 'flipper', '>= 0.15'
 
   spec.add_development_dependency 'bundler',   '~> 1.7'
   spec.add_development_dependency 'rake',      '~> 10.0'

--- a/lib/flipper/echo/version.rb
+++ b/lib/flipper/echo/version.rb
@@ -4,6 +4,6 @@ module Flipper
   module Echo
     # Current gem version
     #
-    VERSION = '0.0.4'
+    VERSION = '0.0.5'
   end
 end


### PR DESCRIPTION
I'd like to test support for newer versions of Flipper. I understand its still pre-1.0, but this will allow newer versions of Flipper while not breaking any backwards compatibility or forcing anyone to upgrade before they are ready.